### PR TITLE
Revert "Updated to support hass.io add-in options"

### DIFF
--- a/dasher/Dockerfile
+++ b/dasher/Dockerfile
@@ -18,4 +18,4 @@ RUN cd /root/dasher && npm install
 #RUN chmod a+x /run.sh
 
 #CMD [ "/run.sh" ]
-CMD cd /root/dasher && cp /data/options.json /root/dasher/config/config.json && npm run start
+CMD cd /root/dasher && cp /config/dasher/config.json /root/dasher/config/config.json && npm run start

--- a/dasher/README.md
+++ b/dasher/README.md
@@ -29,8 +29,10 @@ it in your config.
 You define your buttons via the `config.json` file. It's a simple JSON
 file that holds an array of buttons.
 
-The config file must be entered via the Hass.io add-on options.
-The example config below is the preset example provided by the add-on.
+Your config file should be placed in the hassio config dir in a subdir called dasher
+i.e.
+
+.../config/dasher/config.json
 
 
 Here's an example. Note that button two "Party Time" is a home assistant example...
@@ -191,7 +193,7 @@ Check that your dir is /root/dasher then run this:
 Click your Dash button and the script will listen for your device. Dash buttons should appear as manufactured by 'Amazon Technologies Inc.'. Once you have
 its MAC address you will be able to configure it in Dasher by modifying `config.json` after installing Dasher.
 
-Then create a `config.json` via the options entry in the hass.io add-in options. Use the
+Then create a `config.json` in the hass.io config dir `config/dasher` to set up your Dash buttons. Use the
 example to help you. If you just want to test the button press, use the debug button example with the MAC address you found running script/find_button.
 
 

--- a/dasher/config.json
+++ b/dasher/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Dasher",
-  "version": "0.2",
+  "version": "0.1",
   "slug": "dasher",
   "description": "Amazon Dash button support",
   "startup": "before",
@@ -8,68 +8,6 @@
   "url": "https://github.com/james-fry/hassio-addons/tree/master/dasher",
   "map": ["config:rw", "ssl"],
   "host_network": "True",
-  "options": {
-    "buttons":[
-      {
-        "name": "Notify",
-        "address": "43:02:dc:b2:ab:23",
-        "interface": "en0",
-        "timeout": "60000",
-        "protocol": "udp",
-        "url": "https://maker.ifttt.com/trigger/Notify/with/key/5212ssx2k23k2k",
-        "method": "POST",
-        "json": true,
-        "body": {"value1": "any value", "value2": "another value", "value3": "wow, even more value"}
-      },
-      {
-        "name": "Party Time",
-        "address": "d8:02:dc:98:63:49",
-        "url": "http://192.168.1.55:8123/api/services/scene/turn_on",
-        "method": "POST",
-        "headers": {"authorization": "your_password"},
-        "json": true,
-        "body": {"entity_id": "scene.party_time"},
-        "formData": {
-          "var1":"val1",
-          "var2":" val2"
-        }
-      },
-      {
-        "name": "Start Cooking Playlist",
-        "address": "66:a0:dc:98:d2:63",
-        "url": "http://192.168.1.55:8181/playlists/cooking/play",
-        "method": "PUT"
-      },
-      {
-        "name": "Debug Dash Button",
-        "address": "41:02:dc:b2:ab:23",
-        "debug": true
-      },
-      {
-        "name": "Command Exec Button",
-        "address": "41:02:dc:b2:10:12",
-        "cmd": "/home/user/dash_button.sh"
-      }
-    ]
-  },
-  "schema":
-  {
-    "buttons": [
-      {
-        "name": "str",
-        "address": "str",
-        "interface": "str",
-        "timeout": "int",
-        "protocol": "str",
-        "url": "str",
-        "method": "str",
-        "headers": "str",
-        "json": "bool",
-        "body": "str",
-        "formData": "str",
-        "debug": "str",
-        "cmd": "str"
-      }
-    ]
-  }
+  "options": {},
+  "schema": {}
 }


### PR DESCRIPTION
Reverts james-fry/hassio-addons#2

Due to constraints in the permitted schema for hass.io add-on options, the dasher config is not natively compatible. Hence I am rolling back the change to the previous solution to use sub dir in /config.