### PR TITLE
RTL433 to MQTT Bridge hass.io addon

### DIFF
--- a/rtl4332mqtt/Dockerfile
+++ b/rtl4332mqtt/Dockerfile
@@ -1,0 +1,51 @@
+# Docker file to create an image for a hass.io add-on that contains enough software to listen to events via RTL_SDR/RTL_433 and then publish them to a MQTT broker.
+# The script resides in a volume and can be modified to meet your needs.
+# This hass.io addon is based on Chris Kacerguis' project here: https://github.com/chriskacerguis/honeywell2mqtt,
+# which is in turn based on Marco Verleun's rtl2mqtt image here: https://github.com/roflmao/rtl2mqtt
+
+# IMPORTANT: The container needs privileged access to /dev/bus/usb on the host.
+
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
+ENV LANG C.UTF-8
+
+MAINTAINER James Fry
+
+LABEL Description="This image is used to start a script that will monitor for RF events on 433Mhz (configurable) and send the data to an MQTT server"
+
+#
+# First install software packages needed to compile rtl_433 and to publish MQTT events
+#
+RUN apk add --no-cache --virtual build-deps alpine-sdk cmake git libusb-dev && \
+    mkdir /tmp/src && \
+    cd /tmp/src && \
+    git clone git://git.osmocom.org/rtl-sdr.git && \
+    mkdir /tmp/src/rtl-sdr/build && \
+    cd /tmp/src/rtl-sdr/build && \
+    cmake ../ -DINSTALL_UDEV_RULES=ON -DDETACH_KERNEL_DRIVER=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr/local && \
+    make && \
+    make install && \
+    chmod +s /usr/local/bin/rtl_* && \
+    cd /tmp/src/ && \
+    git clone https://github.com/james-fry/rtl_433 && \
+    cd rtl_433/ && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    make && \
+    make install && \
+    apk del build-deps && \
+    rm -r /tmp/src && \
+    apk add --no-cache libusb mosquitto-clients jq
+
+#
+# Define an environment variable
+#
+# Use this variable when creating a container to specify the MQTT broker host.
+ENV MQTT_HOST="hassio.local"
+ENV MQTT_USER="guest"
+ENV MQTT_PASS="guest"
+ENV MQTT_TOPIC="homeassistant/sensor/rtl433"
+
+CMD cd / && cp /config/rtl4332mqtt/rtl2mqtt.sh /rtl2mqtt.sh && chmod +x /rtl2mqtt.sh && /rtl2mqtt.sh

--- a/rtl4332mqtt/LICENSE
+++ b/rtl4332mqtt/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Chris Kacerguis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rtl4332mqtt/README.md
+++ b/rtl4332mqtt/README.md
@@ -1,0 +1,89 @@
+# RTL433 to MQTT Bridge hass.io addon
+A hass.io addon for a software defined radio tuned to listen for 433MHz RF transmissions and republish the data via MQTT
+
+This hass.io addon is based on Chris Kacerguis' project here: https://github.com/chriskacerguis/honeywell2mqtt,
+which is in turn based on Marco Verleun's rtl2mqtt image here: https://github.com/roflmao/rtl2mqtt
+
+## Usage
+
+1) Install the addon.
+
+2) Use addon configuration to configure:
+- mqtt_host
+- mqtt_user
+- mqtt_password
+- mqtt_topic
+- protocol (see https://github.com/merbanan/rtl_433 for more details inc protocol IDs)
+
+3) Copy rtl2mqtt.sh to your hass.io config dir in a subdir called rtl4332mqt.
+i.e.
+.../config/rtl4332mqtt/rtl2mqtt.sh
+This allows you to edit the start script if you need to make any changes
+
+4) Start the addon
+
+
+## MQTT Data
+
+Data to the MQTT server will depend on the protocol.
+Chris tested Honeywell devices and the JSON is as follows:
+
+```json
+{
+    "time" : "2017-08-17 13:18:58",
+    "model" : "Honeywell Door/Window Sensor",
+    "id" : 547651,
+    "channel" : 8,
+    "event" : 4,
+    "state" : "closed",
+    "heartbeat" : "yes"
+}
+```
+
+I have tested CurrentCost devices and the JSON is as follows:
+
+```json
+{
+    "time" : "2017-10-16 20:53:09",
+    "model" : "CurrentCost TX",
+    "dev_id" : 3063,
+    "power0" : 617,
+    "power1" : 0,
+    "power2" : 0
+}
+```
+
+## Hardware
+
+This has been tested and used with the following hardware (you can get it on Amazon)
+
+Chris:
+- Honeywell Ademco 5818MNL Recessed Door Transmitter
+- 5800MINI Wireless Door/Window Contact by Honeywell
+- NooElec NESDR Nano 2+ Tiny Black RTL-SDR USB
+
+Me:
+- CurrentCost TX: http://www.ebay.co.uk/itm/Current-Cost-Envi-R-Energy-Monitor-Smart-Electric-Meter-/152084708754
+- Super cheap RTL dongle: http://www.ebay.co.uk/itm/Mini-USB-DVB-T-RTL-SDR-Realtek-RTL2832U-R820T-Stick-Receiver-Dongle-MCX-Input-PK/222637370515
+
+
+## Troubleshooting
+
+If you see this error:
+
+> Kernel driver is active, or device is claimed by second instance of librtlsdr.
+> In the first case, please either detach or blacklist the kernel module
+> (dvb_usb_rtl28xxu), or enable automatic detaching at compile time.
+
+Then run the following command on the host
+
+```bash
+sudo rmmod dvb_usb_rtl28xxu rtl2832
+```
+
+## Note
+
+Due to a bug in RTL_433 I am currently using a fork with changes to remove the bug.
+As/when the defect is fixed in RTL_433 then I will update the dockerfile to revert to the rtl_433 master
+See: https://github.com/merbanan/rtl_433/issues/610
+My fork: https://github.com/james-fry/rtl_433 where you can view the delta

--- a/rtl4332mqtt/config.json
+++ b/rtl4332mqtt/config.json
@@ -1,0 +1,27 @@
+{
+  "name": "RTL_433 to MQTT Bridge",
+  "version": "0.1",
+  "slug": "rtl4332mqtt",
+  "description": "433MHz RF to MQTT Bridge based on RTL_SDR/RTL_433 for RTL2832U based DVB-T USB tuners",
+  "startup": "before",
+  "boot": "auto",
+  "map": ["config:rw", "ssl"],
+  "devices": ["/dev/bus/usb:/dev/bus/usb:rwm"],
+  "host_network": "False",
+  "options":
+  {
+    "mqtt_host": "hassio.local",
+    "mqtt_user": "",
+    "mqtt_password": "",
+    "mqtt_topic": "homeassistant/sensor/currentcost",
+    "protocol": 44
+  },
+  "schema":
+  {
+    "mqtt_host": "str",
+    "mqtt_user": "str",
+    "mqtt_password": "str",
+    "mqtt_topic": "str",
+    "protocol": "int"
+   }
+}

--- a/rtl4332mqtt/rtl2mqtt.sh
+++ b/rtl4332mqtt/rtl2mqtt.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+
+# A simple script that will receive events from an RTL433 SDR and resend the data via MQTT
+
+# Author: Chris Kacerguis <chriskacerguis@gmail.com>
+# Modification for hass.io add-on: James Fry
+
+# Below are rtl_433 options and the supported device protocols as of 25/10/2017
+# **NOTE that the protocol number is NOT persistent and seems to change**
+# Hence always verify protocol numbers in logs when starting the add-on
+# The key arguments required are:
+# -F json  --> this sets JSON formatted output for easier MQTT
+# -R <protocol number>  --> this tells rtl_433 which protocol(s) to scan for
+
+# Usage:  = Tuner options =
+#         [-d <RTL-SDR USB device index>] (default: 0)
+#         [-g <gain>] (default: 0 for auto)
+#         [-f <frequency>] [-f...] Receive frequency(s) (default: 433920000 Hz)
+#         [-H <seconds>] Hop interval for polling of multiple frequencies (default: 600 seconds)
+#         [-p <ppm_error] Correct rtl-sdr tuner frequency offset error (default: 0)
+#         [-s <sample rate>] Set sample rate (default: 250000 Hz)
+#         [-S] Force sync output (default: async)
+#         = Demodulator options =
+#         [-R <device>] Enable only the specified device decoding protocol (can be used multiple times)
+#         [-G] Enable all device protocols, included those disabled by default
+#         [-l <level>] Change detection level used to determine pulses [0-16384] (0 = auto) (default: 0)
+#         [-z <value>] Override short value in data decoder
+#         [-x <value>] Override long value in data decoder
+#         [-n <value>] Specify number of samples to take (each sample is 2 bytes: 1 each of I & Q)
+#         = Analyze/Debug options =
+#         [-a] Analyze mode. Print a textual description of the signal. Disables decoding
+#         [-A] Pulse Analyzer. Enable pulse analyzis and decode attempt
+#         [-I] Include only: 0 = all (default), 1 = unknown devices, 2 = known devices
+#         [-D] Print debug info on event (repeat for more info)
+#         [-q] Quiet mode, suppress non-data messages
+#         [-W] Overwrite mode, disable checks to prevent files from being overwritten
+#         [-y <code>] Verify decoding of demodulated test data (e.g. "{25}fb2dd58") with enabled devices
+#         = File I/O options =
+#         [-t] Test signal auto save. Use it together with analyze mode (-a -t). Creates one file per signal
+#                  Note: Saves raw I/Q samples (uint8 pcm, 2 channel). Preferred mode for generating test files
+#         [-r <filename>] Read data from input file instead of a receiver
+#         [-m <mode>] Data file mode for input / output file (default: 0)
+#                  0 = Raw I/Q samples (uint8, 2 channel)
+#                  1 = AM demodulated samples (int16 pcm, 1 channel)
+#                  2 = FM demodulated samples (int16) (experimental)
+#                  3 = Raw I/Q samples (cf32, 2 channel)
+#                  Note: If output file is specified, input will always be I/Q
+#         [-F] kv|json|csv Produce decoded output in given format. Not yet supported by all drivers.
+#                 append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
+#         [-C] native|si|customary Convert units in decoded output.
+#         [-T] specify number of seconds to run
+#         [-U] Print timestamps in UTC (this may also be accomplished by invocation with TZ environment variable set).
+#         [<filename>] Save data stream to output file (a '-' dumps samples to stdout)
+#
+# Supported device protocols:
+#     [01]* Silvercrest Remote Control
+#     [02]  Rubicson Temperature Sensor
+#     [03]  Prologue Temperature Sensor
+#     [04]  Waveman Switch Transmitter
+#     [05]* Steffen Switch Transmitter
+#     [06]* ELV EM 1000
+#     [07]* ELV WS 2000
+#     [08]  LaCrosse TX Temperature / Humidity Sensor
+#     [09]* Template decoder
+#     [10]* Acurite 896 Rain Gauge
+#     [11]  Acurite 609TXC Temperature and Humidity Sensor
+#     [12]  Oregon Scientific Weather Sensor
+#     [13]  Mebus 433
+#     [14]* Intertechno 433
+#     [15]  KlikAanKlikUit Wireless Switch
+#     [16]  AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)
+#     [17]  Cardin S466-TX2
+#     [18]  Fine Offset Electronics, WH2 Temperature/Humidity Sensor
+#     [19]  Nexus Temperature & Humidity Sensor
+#     [20]  Ambient Weather Temperature Sensor
+#     [21]  Calibeur RF-104 Sensor
+#     [22]* X10 RF
+#     [23]* DSC Security Contact
+#     [24]* Brennenstuhl RCS 2044
+#     [25]  GT-WT-02 Sensor
+#     [26]  Danfoss CFR Thermostat
+#     [27]* Energy Count 3000 (868.3 MHz)
+#     [28]* Valeo Car Key
+#     [29]  Chuango Security Technology
+#     [30]  Generic Remote SC226x EV1527
+#     [31]  TFA-Twin-Plus-30.3049 and Ea2 BL999
+#     [32]  Fine Offset Electronics WH1080/WH3080 Weather Station
+#     [33]  WT450
+#     [34]  LaCrosse WS-2310 Weather Station
+#     [35]  Esperanza EWS
+#     [36]  Efergy e2 classic
+#     [37]* Inovalley kw9015b, TFA Dostmann 30.3161 (Rain and temperature sensor)
+#     [38]  Generic temperature sensor 1
+#     [39]  WG-PB12V1
+#     [40]* Acurite 592TXR Temp/Humidity, 5n1 Weather Station, 6045 Lightning
+#     [41]* Acurite 986 Refrigerator / Freezer Thermometer
+#     [42]  HIDEKI TS04 Temperature, Humidity, Wind and Rain Sensor
+#     [43]  Watchman Sonic / Apollo Ultrasonic / Beckett Rocket oil tank monitor
+#     [44]  CurrentCost Current Sensor
+#     [45]  emonTx OpenEnergyMonitor
+#     [46]  HT680 Remote control
+#     [47]  S3318P Temperature & Humidity Sensor
+#     [48]  Akhan 100F14 remote keyless entry
+#     [49]  Quhwa
+#     [50]  OSv1 Temperature Sensor
+#     [51]  Proove
+#     [52]  Bresser Thermo-/Hygro-Sensor 3CH
+#     [53]  Springfield Temperature and Soil Moisture
+#     [54]  Oregon Scientific SL109H Remote Thermal Hygro Sensor
+#     [55]  Acurite 606TX Temperature Sensor
+#     [56]  TFA pool temperature sensor
+#     [57]  Kedsum Temperature & Humidity Sensor
+#     [58]  blyss DC5-UK-WH (433.92 MHz)
+#     [59]  Steelmate TPMS
+#     [60]  Schrader TPMS
+#     [61]* LightwaveRF
+#     [62]  Elro DB286A Doorbell
+#     [63]  Efergy Optical
+#     [64]  Honda Car Key
+#     [65]* Template decoder
+#     [66]  Fine Offset Electronics, XC0400
+#     [67]  Radiohead ASK
+#     [68]  Kerui PIR Sensor
+#     [69]  Fine Offset WH1050 Weather Station
+#     [70]  Honeywell Door/Window Sensor
+#     [71]  Maverick ET-732/733 BBQ Sensor
+#     [72]* RF-tech
+#     [73]  LaCrosse TX141TH-Bv2 sensor
+#     [74]  Acurite 00275rm,00276rm Temp/Humidity with optional probe
+#     [75]  LaCrosse TX35DTH-IT Temperature sensor
+#     [76]  LaCrosse TX29IT Temperature sensor
+#     [77]  Vaillant calorMatic 340f Central Heating Control
+#     [78]  Fine Offset Electronics, WH25 Temperature/Humidity/Pressure Sensor
+#     [79]  Fine Offset Electronics, WH0530 Temperature/Rain Sensor
+#     [80]  IBIS beacon
+#     [81]  Oil Ultrasonic STANDARD FSK
+#     [82]  Citroen TPMS
+#     [83]  Oil Ultrasonic STANDARD ASK
+#     [84]  Thermopro TP11 Thermometer
+#     [85]  Solight TE44
+#     [86]  Wireless Smoke and Heat Detector GS 558
+#     [87]  Generic wireless motion sensor
+#     [88]  Toyota TPMS
+#     [89]  Ford TPMS
+#     [90]  Renault TPMS
+#     [91]* inFactory
+#
+# * Disabled by default, use -R n or -G
+
+set -x
+
+export LANG=C
+PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+
+# Start the listener and enter an endless loop
+echo "Starting RTL..."
+# This example uses 345MHz to scan for Honeywell devices
+#/usr/local/bin/rtl_433 -f 345000000 -F json -R 70 | while read line
+
+# This example uses 433MHz and will scan for CurrentCost
+/usr/local/bin/rtl_433 -F json -R 44 | while read line
+do
+  # Create file with touch /tmp/rtl_433.log if logging is needed
+  [ -w /tmp/rtl_433.log ] && echo $line >> rtl_433.log
+  echo $line | /usr/bin/mosquitto_pub -h $MQTT_HOST -u $MQTT_USER -P $MQTT_PASS -i RTL_433 -r -l -t $MQTT_TOPIC
+done


### PR DESCRIPTION
A hass.io addon for a software defined radio tuned to listen for 433MHz
RF transmissions and republish the data via MQTT

This hass.io addon is
based on Chris Kacerguis' project here:
https://github.com/chriskacerguis/honeywell2mqtt,
which is in turn based
on Marco Verleun's rtl2mqtt image here:
https://github.com/roflmao/rtl2mqtt