### PR TITLE
Fixing config.json files

### DIFF
--- a/dasher/config.json
+++ b/dasher/config.json
@@ -9,5 +9,11 @@
   "map": ["config:rw", "ssl"],
   "host_network": "True",
   "options": {},
-  "schema": {}
+  "schema": {},
+  "arch": [
+    "aarch64",
+    "amd64",
+    "armv7",
+    "i386"
+]
 }

--- a/rtl4332mqtt/config.json
+++ b/rtl4332mqtt/config.json
@@ -9,6 +9,12 @@
   "map": ["config:rw", "ssl"],
   "devices": ["/dev/bus/usb:/dev/bus/usb:rwm"],
   "host_network": "False",
+  "arch": [
+    "aarch64",
+    "amd64",
+    "armv7",
+    "i386"
+  ]
   "options":
   {
     "mqtt_host": "hassio.local",

--- a/rtl4332mqtt/config.json
+++ b/rtl4332mqtt/config.json
@@ -14,7 +14,7 @@
     "amd64",
     "armv7",
     "i386"
-  ]
+  ],
   "options":
   {
     "mqtt_host": "hassio.local",


### PR DESCRIPTION
I have added a required code "ARCH" on config.json files. Now Home Assistant shows and import these addons without errors.